### PR TITLE
Add mocha tests and fix a possible bug that came up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dietechniker/gulp-sass-dependency-tracker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A NodeJS gulp package to optimize sass compilation - only compile what you actually changed.",
   "keywords": [
     "gulp",
@@ -42,6 +42,10 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "vinyl": "^2.2.0"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
   "engines": {
     "node": "^8.9.4",
     "npm": "^5.6.0"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "mocha": "^5.2.0"
   }
 }

--- a/readMe.md
+++ b/readMe.md
@@ -1,4 +1,4 @@
-# GulpSassDependencyTracker
+# GulpSassDependencyTracker [![GitHub version](https://badge.fury.io/gh/DieTechniker%2Fgulp-sass-dependency-tracker.svg)](https://badge.fury.io/gh/DieTechniker%2Fgulp-sass-dependency-tracker) [![npm version](https://badge.fury.io/js/%40dietechniker%2Fgulp-sass-dependency-tracker.svg)](https://badge.fury.io/js/%40dietechniker%2Fgulp-sass-dependency-tracker)
 
 A NodeJS module for keeping things easy in sass tasks for Gulp.  
 This gulp plugin filters the file stream to include only scss files that have to be recompiled.  
@@ -23,6 +23,7 @@ gulp.task('sass', function () {
                 .pipe(sassDepTracker.inspect(sassOptions))
                 .pipe(sassDepTracker.logFiles())
                 .pipe(sass(sassOptions).on('error', sass.logError))
+                .pipe(sassDepTracker.reportCompiled())
                 .pipe(gulp.dest('.'))
 });
 
@@ -50,7 +51,9 @@ As you can see, we have four main things to register in order to get things flyi
 2. Pipe the stream into ``DependencyTracker#filter()``  
   2.1 Optionally pipe through ``DependencyTracker#logFiles()`` if you want a notification about whats left in the stream.
 3. Pipe the stream into ``DependencyTracker#inspect(<sassOptions>)``  
-4. Notify the sass helper when a file is removed or changed so we can mark them dirty.  
+4. Pipe the stream into ``gulp-sass`` or any similar compilation package.
+5. Pipe the stream into ``DependencyTracker#reportCompiled()`` to mark them as compiled.
+6. Notify the sass helper when a file is removed or changed so we can mark them dirty.  
 
 Note: On the first run all files in the stream are marked dirty as none of them have been analyzed yet.
 

--- a/test/sass/_partial.scss
+++ b/test/sass/_partial.scss
@@ -1,0 +1,3 @@
+%the-element {
+  color: blue;
+}

--- a/test/sass/child.scss
+++ b/test/sass/child.scss
@@ -1,0 +1,6 @@
+@import "parent";
+@import "partial";
+
+.the-element {
+  @extend %the-element
+}

--- a/test/sass/parent.scss
+++ b/test/sass/parent.scss
@@ -1,0 +1,3 @@
+.some-element {
+  color: green;
+}

--- a/test/sass/unrelated.scss
+++ b/test/sass/unrelated.scss
@@ -1,0 +1,1 @@
+@import 'parent';

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+
+const gulp = require('gulp');
+const dependencyTracker = new require('../src/dependency-tracker');
+
+process.chdir('test');
+
+before(function () {
+    gulp.src('sass/*.scss')
+        .pipe(dependencyTracker.inspect());
+});
+
+describe('Import-Detection', function () {
+    describe('#inspect()', function () {
+        it('child depends on \'parent\'', function () {
+
+        });
+
+        it('child depends on \'partial\'', function () {
+
+        });
+    })
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,23 +1,149 @@
+'use strict';
+
+// --- Dependencies --- //
 const assert = require('assert');
 
 const gulp = require('gulp');
-const dependencyTracker = new require('../src/dependency-tracker');
+const map = require('map-stream');
+const Vinyl = require('vinyl');
+
+const path = require('../src/path-ponyfill');
+const SassDepTracker = require('../index');
+const dependencyTracker = new SassDepTracker({
+    debug: false,
+    suppressOutput: true
+});
+
+// --- Setup --- //
 
 process.chdir('test');
 
-before(function () {
-    gulp.src('sass/*.scss')
-        .pipe(dependencyTracker.inspect());
+const globPattern = './sass/*.scss';
+
+const sassOptions = {
+    includePathes: [
+        path.resolve('./sass')
+    ]
+};
+
+let commonCWD = path.resolve('./');
+let commonBase = path.resolve('./sass');
+
+let child = new Vinyl({
+    cwd: commonCWD,
+    base: commonBase,
+    path: path.resolve('./sass/child.scss'),
+    contents: null
 });
 
-describe('Import-Detection', function () {
+let parent = new Vinyl({
+    cwd: commonCWD,
+    base: commonBase,
+    path: path.resolve('./sass/parent.scss')
+});
+
+let partialParent = new Vinyl({
+    cwd: commonCWD,
+    base: commonBase,
+    path: path.resolve('./sass/_partial.scss')
+});
+
+let unrelated = new Vinyl({
+    cwd: commonCWD,
+    base: commonBase,
+    path: path.resolve('./sass/unrelated.scss')
+});
+
+// --- Readability helper --- //
+let childPath = path.normalize(child.path);
+
+let getEntry = function(normalizedPath) {
+    normalizedPath = normalizedPath || childPath;
+    // noinspection JSDeprecatedSymbols - function created for this test purpose.
+    return dependencyTracker.getTree().get(normalizedPath);
+};
+
+let getDependencies = () => {
+    return getEntry().get('dependencies');
+};
+
+// --- Mocha tests --- //
+
+describe('SassDependencyTracker', function () {
+    before(function (cb) {
+        dependencyTracker.reset();
+        gulp.src(globPattern)
+            .pipe(dependencyTracker.inspect(sassOptions))
+            .pipe(dependencyTracker.logFiles())
+            .pipe(dependencyTracker.reportCompiled())
+            .on('end', cb);
+    });
+
     describe('#inspect()', function () {
-        it('child depends on \'parent\'', function () {
-
+        it('recognized child', function () {
+            assert.notEqual(getEntry(), null, `Template was not tracked as: ${childPath}!`)
         });
 
-        it('child depends on \'partial\'', function () {
-
+        it('should have two dependencies for child', function () {
+            let dependencies = getEntry().get('dependencies');
+            assert.equal(dependencies.length, 2, 'Dependencies count does not match!')
         });
+
+        it('should list child dependent on \'parent\'', function () {
+            let parentPath = path.normalize(parent.path);
+            assert(getDependencies().includes(parentPath), 'Parent is not listed as dependency!');
+        });
+
+        it('should list child dependent on \'partial\'', function () {
+            let partialPath = path.normalize(partialParent.path);
+            assert(getDependencies().includes(partialPath), 'Partial is not listed as dependency!');
+        });
+    });
+
+    describe('#filter()', function () {
+        let aggregateFilesFromStream = function(files) {
+            return map(function (file, cb) {
+                let filePath = path.normalize(file.path);
+                files.push(filePath);
+                return cb(null, file);
+            });
+        };
+
+        it('will include no file for no changes', function () {
+            let files = [];
+            gulp.src(globPattern)
+                .pipe(dependencyTracker.filter())
+                .pipe(aggregateFilesFromStream(files));
+
+            assert(!files.includes(path.normalize(child.path)), 'Child not filtered!');
+            assert(!files.includes(path.normalize(parent.path)), 'Parent not filtered!');
+            assert(!files.includes(path.normalize(partialParent.path)), 'Partial not filtered!');
+            assert(!files.includes(path.normalize(unrelated.path)), 'Unrelated not filtered!');
+        });
+
+        it('marks two files as dirty', function () {
+            dependencyTracker.queueRebuild(path.normalize(partialParent.path));
+            assert(getEntry(path.normalize(partialParent.path)).get('recompile') === true, 'Partial not queued for rebuild!');
+            assert(getEntry(path.normalize(child.path)).get('recompile') === true, 'Child not queued for rebuild!');
+        });
+
+        it('will include child when partial changes', function () {
+            dependencyTracker.queueRebuild(path.normalize(partialParent.path));
+            let files = [];
+            return new Promise(function (resolve, reject) {
+                gulp.src(globPattern)
+                    .pipe(dependencyTracker.filter())
+                    .pipe(aggregateFilesFromStream(files))
+                    .on('end', function () {
+                        resolve();
+                    })
+                    .on('error', reject);
+            }).then(function () {
+                assert(files.includes(path.normalize(child.path)), 'Child not included!');
+                assert(!files.includes(path.normalize(parent.path)), 'Parent not filtered!');
+                assert(files.includes(path.normalize(partialParent.path)), 'Partial not included!');
+                assert(!files.includes(path.normalize(unrelated.path)), 'Unrelated not filtered!');
+            });
+        })
     })
 });


### PR DESCRIPTION
While coding the mocha tests, a bug came up that occurs when the module is used without ``logFiles()``.  
Although marked as optional that call actually was responsible for marking source files as compiled so they would be excluded by ``filter()``.  
This PR includes a fix for that by introducing ``reportCompiled()`` which should be called after the sass compilation call. 