### PR TITLE
Fix for #reportCompiled with renamed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dietechniker/gulp-sass-dependency-tracker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A NodeJS gulp package to optimize sass compilation - only compile what you actually changed.",
   "keywords": [
     "gulp",
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
+    "gulp-rename": "^1.4.0",
     "mocha": "^5.2.0",
     "vinyl": "^2.2.0"
   },

--- a/src/dependency-tracker.js
+++ b/src/dependency-tracker.js
@@ -120,8 +120,18 @@ class DependencyTracker {
     reportCompiled() {
         let me = this;
         return map(function (file, cb) {
-            let filepath = path.normalize(file.path);
-            me.getOrCreateEntry(filepath).set('recompile', false);
+            // Support for renaming files.
+            // Search for the earliest name ending in the scss extension.
+            for (let filePath of file.history) {
+                if (filePath.endsWith('.scss')) {
+                    filePath = path.normalize(filePath);
+                    me.getOrCreateEntry(filePath).set('recompile', false);
+
+                    if (me.isDebug()) {
+                        log.info(`Compiled: ${filePath}`);
+                    }
+                }
+            }
             cb(null, file)
         })
     }


### PR DESCRIPTION
When a vinyl file got renamed between ``#inspect()`` and ``#reportCompiled()``, the dirty-marker failed to get set correctly resulting in all renamed files always being dirty.  
We now prevent this by searching the vinyl file history for the first occurrence of a name ending in ``.scss``
