### PR TITLE
Create class for dependency tree & Improve code readability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dietechniker/gulp-sass-dependency-tracker",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A NodeJS gulp package to optimize sass compilation - only compile what you actually changed.",
   "keywords": [
     "gulp",

--- a/src/dependency-tracker.js
+++ b/src/dependency-tracker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // General utilities
-const log = require('fancy-log');
+const logging = require('./logging');
 
 // Stream utilities
 const map = require('map-stream');
@@ -15,25 +15,6 @@ const inspectStream = require('./inspect-stream');
 
 // Ponyfill for `path`
 const path = require('./path-ponyfill');
-
-const colorSupport = require('color-support');
-const color = require('cli-color');
-
-const c = {};
-if (colorSupport.level > 0) {
-    c.success = color.greenBright;
-    c.info = color.white;
-    c.debug = color.blackBright;
-    c.warn = color.yellow;
-    c.error = color.red;
-} else {
-    let dummy = msg => msg;
-    c.success = dummy;
-    c.info = dummy;
-    c.debug = dummy;
-    c.warn = dummy;
-    c.error = dummy;
-}
 
 const SassDependencyTree = require('./dependency-tree');
 
@@ -113,7 +94,7 @@ class DependencyTracker {
         return map(function (file, cb) {
             if (!me.isOutputSuppressed()) {
                 let filePath = path.normalize(file.path);
-                log.info(c.debug(`Will be compiling: ${filePath}`));
+                logging.log.info(logging.colors.debug(`Will be compiling: ${filePath}`));
             }
             return cb(null, file);
         });
@@ -173,7 +154,7 @@ class DependencyTracker {
             this.sassTree.addDependency(file, importFilePath);
 
         } else {
-            log.warn(c.warn(`Unable to resolve dependency "${importPath} for ${filePath}`));
+            logging.log.warn(logging.colors.warn(`Unable to resolve dependency "${importPath} for ${filePath}`));
         }
     }
 

--- a/src/dependency-tracker.js
+++ b/src/dependency-tracker.js
@@ -35,23 +35,31 @@ if (colorSupport.level > 0) {
     c.error = dummy;
 }
 
+const SassDependencyTree = require('./dependency-tree');
+
 const importRegex = /@import ['"]([\w./-]+)['"];/g;
 
 /**
  * Main class of a helpful module for sass compilation tasks with GulpJS.
  * For the full module documentation please consult the readMe.md file.
+ *
+ * @property sassTree {SassDependencyTree} Manager of the dependency tree. Please use {@link getTree} instead of directly accessing this property so the contract can be upheld!
  */
 class DependencyTracker {
+
+    // --- Private fields --- //
+
+    // TODO: Use when supported by Node.
+    //#sassTree;
+
+    // --- Public methods --- //
 
     /**
      * Constructs a new tracker instance.
      */
-    constructor(options) {
-        this.sass_tree = new Map();
-        this.options = options || {
-            debug: false,
-            suppressOutput: false
-        }
+    constructor(options = {debug: false, suppressOutput: false}) {
+        this.sassTree = new SassDependencyTree(options);
+        this.options = options;
     }
 
     /**
@@ -76,7 +84,7 @@ class DependencyTracker {
     filter() {
         const me = this;
         return gIgnore.include(function (file) {
-            return !file.path.endsWith('.scss') || me.needsRebuild(file);
+            return !file.path.endsWith('.scss') || !me.getTree().isCompiled(file);
         });
     }
 
@@ -124,12 +132,7 @@ class DependencyTracker {
             // Search for the earliest name ending in the scss extension.
             for (let filePath of file.history) {
                 if (filePath.endsWith('.scss')) {
-                    filePath = path.normalize(filePath);
-                    me.getOrCreateEntry(filePath).set('recompile', false);
-
-                    if (me.isDebug()) {
-                        log.info(c.debug(`Compiled: ${filePath}`));
-                    }
+                    me.getTree().markAsCompiled(filePath);
                 }
             }
             cb(null, file)
@@ -140,7 +143,7 @@ class DependencyTracker {
      * Resets the dependency tracker to its initial state after construction.
      */
     reset() {
-        this.sass_tree.clear();
+        this.sassTree.clear();
     }
 
     /**
@@ -167,10 +170,7 @@ class DependencyTracker {
         }
 
         if (importFilePath) {
-            this.getOrCreateEntry(filePath).get('dependencies').push(importFilePath);
-            if (this.isDebug()) {
-                log.info(c.debug(`${file.path} =dep=> ${importFilePath}`));
-            }
+            this.sassTree.addDependency(file, importFilePath);
 
         } else {
             log.warn(c.warn(`Unable to resolve dependency "${importPath} for ${filePath}`));
@@ -178,33 +178,12 @@ class DependencyTracker {
     }
 
     /**
-     * Convenience function to gracefully get entries from the internal mapping.
-     *
-     * @param normalizedPath Normalized absolute file path.
-     * @returns {Map}
-     */
-    getOrCreateEntry(normalizedPath) {
-        if (!this.sass_tree.has(normalizedPath)) {
-            let entry = new Map();
-            entry.set('recompile', true);
-            entry.set('dependencies', []);
-            this.sass_tree.set(normalizedPath, entry);
-        }
-
-        return this.sass_tree.get(normalizedPath);
-    }
-
-    /**
      * Returns whether or not a file has been marked for a rebuild.
-     *
-     * @param file A Vinyl file or a normalized absolute path.
-     * @returns {boolean}
+     * @see SassDependencyTree#isCompiled for more information.
+     * @param file {Vinyl|Map|string|object}
      */
     needsRebuild(file) {
-        let filePath = (typeof  file === 'string') ? file : file.path;
-        filePath = path.normalize(filePath);
-
-        return this.getOrCreateEntry(filePath).get('recompile') === true;
+        return this.sassTree.isCompiled(file);
     }
 
     /**
@@ -214,46 +193,17 @@ class DependencyTracker {
      * @param file A Vinyl file or a normalized absolute path.
      */
     queueRebuild(file) {
-        let filePath = (typeof file === 'string') ? file : file.path;
-        filePath = path.normalize(filePath);
-
-        if (!this.isOutputSuppressed()) {
-            log.info(c.info(`Queuing ${filePath} for rebuild.`));
-        }
-
-        let mapEntry = this.getOrCreateEntry(filePath);
-        mapEntry.set('recompile',true);
-
-        let rebuildDepends = [];
-        let rebuildCheck = (entry, key, map) => {
-            let dependencies = entry.get('dependencies');
-            if (entry.get('recompile') === false && dependencies.includes(filePath)) {
-                rebuildDepends.push(key);
-
-                if (this.isDebug()) {
-                    log.info(c.debug(`Found dependency: ${key}`));
-                }
-            }
-        };
-
-        let rebuildQueue = entry => {
-            this.queueRebuild(entry);
-        };
-
-        this.sass_tree.forEach(rebuildCheck);
-        rebuildDepends.forEach(rebuildQueue);
+        this.sassTree.markAsNotCompiled(file);
     }
 
     /**
      * Accessor for the dependency tree.
-     * This is mainly used in our test cases.
-     * We strongly advice you against using this.
+     * Use its public contract for manually adding/removing dependencies and/or marking compilation state.
      *
-     * @returns {Map<String, Object>}
-     * @deprecated As an advice to not use this.
+     * @returns {SassDependencyTree}
      */
     getTree() {
-        return this.sass_tree;
+        return this.sassTree;
     }
 }
 

--- a/src/dependency-tree.js
+++ b/src/dependency-tree.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const path = require('./path-ponyfill');
+const Vinyl = require('vinyl');
+const logging = require('./logging');
+
+/**
+ * Retrieves a path from a file-like input parameter.
+ * Convenience function so we support more than just strict normalized paths.
+ * May be:
+ * * Vinyl file
+ * * Map containing a 'path' key with the resolvable path
+ * * string as the resolvable path itself
+ * * object containing a 'path' property as the resolvable path
+ *
+ * @param file {Vinyl|Map<string, string>|string|object}
+ * @return {string} the resolved file path.
+ */
+function fileArgumentToNormalizedPath(file) {
+    if (file !== undefined && file !== null) {
+
+        if (Vinyl.isVinyl(file)) {
+            return path.normalize(file.path);
+        }
+
+        let typeName = typeof file;
+        if (file instanceof Map && file.has('path')) {
+            return fileArgumentToNormalizedPath(file.get('path'));
+
+        } else if (typeName === 'string') {
+            return path.normalize(path.resolve(file));
+
+        } else if (typeName === 'object' && file.hasOwnProperty('path')) {
+            return path.normalize(path.resolve(file.path));
+
+        } else if (typeName === 'object' && file.path !== undefined && file.path !== null) {
+            return path.normalize(path.resolve(file.path));
+        }
+    }
+
+    throw new Error(`Cannot retrieve normalized path from: ${file}`)
+}
+
+const _getOrCreateEntry = Symbol('internalGetOrCreateEntry');
+const _getDependencies = Symbol('internalGetDependencies');
+const _isDebug = Symbol('isDebug');
+const _isOutputSuppressed = Symbol('isOutputSuppressed');
+
+/**
+ * @property internalTree {Map} Internal representation of the dependency tree. Avoid using this as it may change EVEN IN MINOR UPDATES!
+ */
+class SassDependencyTree {
+
+    // --- Private fields --- //
+
+    // TODO: Use when supported by Node.
+    //#internalTree;
+    //#options;
+
+    // --- Public methods --- //
+
+    constructor(options = {debug: false, suppressOutput: false}) {
+        this.internalTree = new Map();
+        this.options = options;
+    }
+
+    /**
+     * Adds a direct dependency to the tracking for a file.
+     *
+     * @param sourceFile {Vinyl|Map|string|object} The file that has the dependency. File-like by: {@link fileArgumentToNormalizedPath}
+     * @param dependencyFile {Vinyl|Map|string|object} The file that is the dependency File-like by: {@link fileArgumentToNormalizedPath}
+     * @return {void}
+     */
+    addDependency(sourceFile, dependencyFile) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        let dependencyPath = fileArgumentToNormalizedPath(dependencyFile);
+
+        if (this[_isDebug] && !this[_isOutputSuppressed]) {
+            logging.log.info(logging.colors.debug(`Dependency added: ${sourceFilePath} => ${dependencyPath}`));
+        }
+
+        let entry = this[_getOrCreateEntry](sourceFilePath);
+        entry.get('dependencies').push(dependencyPath);
+    }
+
+    /**
+     * Removes a direct dependency to the tracking for a file.
+     *
+     * @param sourceFile {Vinyl|Map|string|object} The file that has the dependency. File-like by: {@link fileArgumentToNormalizedPath}
+     * @param dependencyFile {Vinyl|Map|string|object} The file that is the dependency File-like by: {@link fileArgumentToNormalizedPath}
+     * @return {void}
+     */
+    removeDependency(sourceFile, dependencyFile) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        let dependencyPath = fileArgumentToNormalizedPath(dependencyFile);
+
+        if (this[_isDebug] && !this[_isOutputSuppressed]) {
+            logging.log.info(logging.colors.debug(`Dependency removed: ${sourceFilePath} =/=> ${dependencyPath}`));
+        }
+
+        let entry = this[_getOrCreateEntry](sourceFilePath);
+        let directDependencies = entry.get('dependencies');
+        let dependencyIndex = directDependencies.indexOf(dependencyPath);
+        if (dependencyIndex >= 0) {
+            directDependencies.remove(dependencyIndex);
+        }
+    }
+
+    /**
+     * Lists the dependencies of a particular file.
+     *
+     * @param sourceFile {Vinyl|Map|string|object} The file that has the dependencies. File-like by: {@link fileArgumentToNormalizedPath}
+     * @param deep {boolean} Whether or not to recursively look up the files dependencies and add them to the result.
+     * @return {Array} Of normalized string paths. The dependencies of that file.
+     */
+    getDependencies(sourceFile, deep = false) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        let dependencies = [];
+        this[_getDependencies](sourceFilePath, dependencies.push, deep);
+        return dependencies;
+    }
+
+    /**
+     * Marks a file as compiled
+     *
+     * @param sourceFile {Vinyl|Map|string|object} The source file. File-like by: {@link fileArgumentToNormalizedPath}
+     * @return {void}
+     */
+    markAsCompiled(sourceFile) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        let entry = this[_getOrCreateEntry](sourceFilePath);
+
+        if (this[_isDebug] && !this[_isOutputSuppressed]) {
+            logging.log.info(logging.colors.debug(`AsCompiled: ${sourceFilePath}`));
+        }
+
+        entry.set('recompile', false);
+    }
+
+    /**
+     * Sets a files state to "not compiled" meaning that it should be included on the next compile run.
+     * Will also mark all files dependent on this file as "not compiled"
+     *
+     * @param sourceFile {Vinyl|Map|string|object} The source file. File-like by: {@link fileArgumentToNormalizedPath}
+     * @return {void}
+     */
+    markAsNotCompiled(sourceFile) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        let entry = this[_getOrCreateEntry](sourceFilePath);
+        entry.set('recompile', true);
+
+        if (this[_isDebug] && !this[_isOutputSuppressed]) {
+            logging.log.info(logging.colors.debug(`Marking for recompilation: ${sourceFilePath}`));
+        }
+
+        let dependingFiles = [];
+        this.internalTree.forEach((value, key) => {
+            let dependencies = value.get('dependencies');
+            if (dependencies.indexOf(sourceFilePath) >= 0
+                && value.get('recompile') === false) {
+                dependingFiles.push(key);
+            }
+        });
+
+        for (let dependent of dependingFiles) {
+            this.markAsNotCompiled(dependent);
+        }
+    }
+
+    /**
+     *
+     * @param sourceFile {Vinyl|Map|string|object} The source file. File-like by: {@link fileArgumentToNormalizedPath}
+     * @return {boolean} Whether or not the file is marked as compiled.
+     */
+    isCompiled(sourceFile) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        let entry = this[_getOrCreateEntry](sourceFilePath);
+        return entry.get('recompile') === false;
+    }
+
+    /**
+     * Clears all dependencies from the internal representation.
+     * @return {void}
+     */
+    clear() {
+        this.internalTree.clear();
+    }
+
+    /**
+     * Public method for our own mocha tests.
+     * It is highly DISCOURAGED to use this function.
+     * Its contract is also not covered by semver!
+     *
+     * @return {Map} the entry for that file
+     * @deprecated To stress the discouragement of this function. Please do not use this in any use case - other than tests maybe.
+     */
+    getEntry(sourceFile) {
+        let sourceFilePath = fileArgumentToNormalizedPath(sourceFile);
+        return this[_getOrCreateEntry](sourceFilePath);
+    }
+
+    // --- Private methods --- //
+
+    [_isDebug]() {
+        return this.options.debug || false;
+    }
+
+    [_isOutputSuppressed]() {
+        return this.options.suppressOutput || false;
+    }
+
+    /**
+     *
+     *
+     * @param normalizedPath
+     * @return {Map} The entry from the dependency tree.
+     */
+    [_getOrCreateEntry](normalizedPath) {
+        let entry = null;
+
+        if (!this.internalTree.has(normalizedPath)) {
+            entry = new Map();
+            entry.set('recompile', true);
+            entry.set('path', normalizedPath);
+            entry.set('dependencies', []);
+            this.internalTree.set(normalizedPath, entry);
+        } else {
+            entry = this.internalTree.get(normalizedPath, entry);
+        }
+
+        return entry;
+    }
+
+    /**
+     *
+     * @param normalizedPath
+     * @param aggregator
+     * @param deep
+     * @return {void}
+     */
+    [_getDependencies](normalizedPath, aggregator, deep = false) {
+        if (aggregator === undefined || aggregator === null || (typeof aggregator) !== 'function') {
+            throw new Error('Cannot aggregate on non-function');
+        }
+
+        let entry = this[_getOrCreateEntry](normalizedPath);
+        let dependencies = entry.get('dependencies');
+
+        for (let dependency of dependencies) {
+            aggregator(dependency);
+
+            if (deep === true) {
+                this[_getDependencies](dependency, aggregator, deep);
+            }
+        }
+    }
+}
+
+module.exports = SassDependencyTree;

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,0 +1,26 @@
+// General utilities
+const log = require('fancy-log');
+
+const colorSupport = require('color-support');
+const color = require('cli-color');
+
+const colors = {};
+if (colorSupport.level > 0) {
+    colors.success = color.greenBright;
+    colors.info = color.white;
+    colors.debug = color.blackBright;
+    colors.warn = color.yellow;
+    colors.error = color.red;
+} else {
+    let dummy = msg => msg;
+    colors.success = dummy;
+    colors.info = dummy;
+    colors.debug = dummy;
+    colors.warn = dummy;
+    colors.error = dummy;
+}
+
+module.exports = {
+    log,
+    colors,
+};

--- a/test/test.js
+++ b/test/test.js
@@ -58,14 +58,13 @@ let unrelated = new Vinyl({
 // --- Readability helper --- //
 let childPath = path.normalize(child.path);
 
-let getEntry = function(normalizedPath) {
-    normalizedPath = normalizedPath || childPath;
+let getEntry = function(file) {
     // noinspection JSDeprecatedSymbols - function created for this test purpose.
-    return dependencyTracker.getTree().get(normalizedPath);
+    return dependencyTracker.getTree().getEntry(file);
 };
 
 let getDependencies = () => {
-    return getEntry().get('dependencies');
+    return getEntry(child).get('dependencies');
 };
 
 let aggregateFilesFromStream = function(files) {
@@ -90,11 +89,11 @@ describe('SassDependencyTracker', function () {
 
     describe('#inspect()', function () {
         it('recognized child', function () {
-            assert.notEqual(getEntry(), null, `Template was not tracked as: ${childPath}!`)
+            assert.notEqual(getEntry(child), null, `Template was not tracked as: ${childPath}!`)
         });
 
         it('should have two dependencies for child', function () {
-            let dependencies = getEntry().get('dependencies');
+            let dependencies = getEntry(child).get('dependencies');
             assert.equal(dependencies.length, 2, 'Dependencies count does not match!')
         });
 
@@ -124,8 +123,8 @@ describe('SassDependencyTracker', function () {
 
         it('marks two files as dirty', function () {
             dependencyTracker.queueRebuild(path.normalize(partialParent.path));
-            assert(getEntry(path.normalize(partialParent.path)).get('recompile') === true, 'Partial not queued for rebuild!');
-            assert(getEntry(path.normalize(child.path)).get('recompile') === true, 'Child not queued for rebuild!');
+            assert(getEntry(partialParent).get('recompile') === true, 'Partial not queued for rebuild!');
+            assert(getEntry(child).get('recompile') === true, 'Child not queued for rebuild!');
         });
 
         it('will include child when partial changes', function () {
@@ -163,8 +162,8 @@ describe('SassDependencyTracker', function () {
                     })
                     .on('error', reject);
             }).then(function () {
-                assert.strictEqual(getEntry(path.normalize(child.path)).get('recompile'), false, 'Child still dirty!');
-                assert.strictEqual(getEntry(path.normalize(partialParent.path)).get('recompile'), false, 'Partial still dirty!');
+                assert.strictEqual(getEntry(child).get('recompile'), false, 'Child still dirty!');
+                assert.strictEqual(getEntry(partialParent).get('recompile'), false, 'Partial still dirty!');
             });
         })
     });


### PR DESCRIPTION
Adds a class for the dependency tree to the module.  
This allows basic customization of the dependency tracking for cases where the normal gulp workflow is not applicable.  
Also now explicitly shows what functions are part of the public contract and thus covered by ``semver``.  
Others are either ``@deprecated`` or private using Symbols.  

Updates minor version ``1.0.2 => 1.1.0`` as the dependency tree is now properly accessible which is considered a new feature.