### PR TITLE
Apply a fix for unresolved relative import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp": "^3.9.1",
     "gulp-rename": "^1.4.0",
     "mocha": "^5.2.0",
+    "path-dirname": "^1.0.2",
     "vinyl": "^2.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dietechniker/gulp-sass-dependency-tracker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A NodeJS gulp package to optimize sass compilation - only compile what you actually changed.",
   "keywords": [
     "gulp",

--- a/src/dependency-tracker.js
+++ b/src/dependency-tracker.js
@@ -143,7 +143,8 @@ class DependencyTracker {
 
         let importFilePath;
         for (let inclPath of includePaths) {
-            importFilePath = resolveImport(importPath, inclPath, path.normalize(file.base));
+            let parentDir = path.normalize(path.dirname(file.path));
+            importFilePath = resolveImport(importPath, inclPath, parentDir);
 
             if (importFilePath) {
                 break;

--- a/src/path-ponyfill.js
+++ b/src/path-ponyfill.js
@@ -11,7 +11,8 @@ const fs = require('fs');
 
 const path = {
     isAbsolute: require('is-absolute'), // path.isAbsolute
-    resolve: require('path-resolve'), // path.resolve;
+    resolve: require('path-resolve'), // path.resolve
+    dirname: require('path-dirname'), // path.dirname
     join: require('path.join'), // path.join
     normalize: require('normalize-path'), // path.normalize
     relative: require('relative').toBase, // path.relative

--- a/test/sass/subdir/2/relative-import.scss
+++ b/test/sass/subdir/2/relative-import.scss
@@ -1,0 +1,1 @@
+@import 'relative-dependency';

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ const dependencyTracker = new SassDepTracker({
 
 process.chdir('test');
 
-const globPattern = './sass/*.scss';
+const globPattern = './sass/**/*.scss';
 
 const sassOptions = {
     includePathes: [
@@ -55,6 +55,18 @@ let unrelated = new Vinyl({
     path: path.resolve('./sass/unrelated.scss')
 });
 
+let reltativeImporting = new Vinyl({
+    cwd: commonCWD,
+    base: path.join(commonBase, 'subdir'),
+    path: path.resolve('./sass/subdir/2/relative-import.scss')
+});
+
+let reltativeDependency = new Vinyl({
+    cwd: commonCWD,
+    base: path.join(commonBase, 'subdir'),
+    path: path.resolve('./sass/subdir/2/relative-dependency.scss')
+});
+
 // --- Readability helper --- //
 let childPath = path.normalize(child.path);
 
@@ -63,8 +75,8 @@ let getEntry = function(file) {
     return dependencyTracker.getTree().getEntry(file);
 };
 
-let getDependencies = () => {
-    return getEntry(child).get('dependencies');
+let getDependencies = (file = child) => {
+    return getEntry(file).get('dependencies');
 };
 
 let aggregateFilesFromStream = function(files) {
@@ -106,6 +118,11 @@ describe('SassDependencyTracker', function () {
             let partialPath = path.normalize(partialParent.path);
             assert(getDependencies().includes(partialPath), 'Partial is not listed as dependency!');
         });
+
+        it('should have resolved the relative dependency', function () {
+            let dependencyPath = path.normalize(reltativeDependency.path);
+            assert(getDependencies(reltativeImporting).includes(dependencyPath), 'Relative import is not found or unresolved!')
+        })
     });
 
     describe('#filter()', function () {


### PR DESCRIPTION
Under certain circumstances, it was possible that a relative import could not be resolved due to gulp setting ``base`` in the ``Vinyl`` object to the glob result dir and not the actual file ``base`` directory.  
We avoid this by calling ``path.dirname`` on the filepath to get the real parent directory of the file.